### PR TITLE
derive Debug by default

### DIFF
--- a/src/element.rs
+++ b/src/element.rs
@@ -253,7 +253,7 @@ impl<T: std::cmp::PartialEq + std::fmt::Display + std::fmt::Debug> Element<T> {
 
         trace.push(self.formatted_name());
 
-        serde_struct.push_str("#[derive(Serialize, Deserialize)]\n");
+        serde_struct.push_str("#[derive(Debug, Serialize, Deserialize)]\n");
         serde_struct.push_str(&format!(
             "pub struct {} {{\n",
             self.expand_name(trace, trace_length)


### PR DESCRIPTION
Could be gated behind a feature flag. Not sure. What do you think?