### PR TITLE
fix: correctly handle repeated element names in different locations

### DIFF
--- a/src/element.rs
+++ b/src/element.rs
@@ -227,12 +227,8 @@ impl<T: std::cmp::PartialEq + std::fmt::Display + std::fmt::Debug> Element<T> {
         let mut name = String::new();
 
         if let Some(n) = trace_length.get(&self.formatted_name()) {
-            if *n <= trace.len() {
-                let start = trace.len() - *n;
-                name = trace[start..].join("")
-            } else {
-                error!("invalid trace for tag {}", &self.name);
-            }
+            let start = trace.len().saturating_sub(*n);
+            name = trace[start..].join("")
         }
         name
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,70 @@ pub struct A {
         assert_eq!(expected, root.to_serde_struct(&Options::quick_xml_de()));
     }
 
+    #[test]
+    fn parse_xml_and_return_shallow_nested_duplicate_struct_as_str() {
+        let xml = "<a><a></a></a>";
+        let mut reader = Reader::from_str(xml);
+
+        let root = into_struct(&mut reader).expect("expected to successfully parse into struct");
+
+        let expected = "\
+#[derive(Serialize, Deserialize)]
+pub struct A {
+    pub a: AA,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct AA {
+}
+
+";
+
+        assert_eq!(expected, root.to_serde_struct(&Options::quick_xml_de()));
+    }
+
+    #[test]
+    fn parse_xml_and_return_deep_nested_duplicate_struct_as_str() {
+        let xml = "<a><b><c><d><e><a></a></e></d></c></b></a>";
+        let mut reader = Reader::from_str(xml);
+
+        let root = into_struct(&mut reader).expect("expected to successfully parse into struct");
+
+        let expected = "\
+#[derive(Serialize, Deserialize)]
+pub struct A {
+    pub b: B,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct B {
+    pub c: C,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct C {
+    pub d: D,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct D {
+    pub e: E,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct E {
+    pub a: ABCDEA,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ABCDEA {
+}
+
+";
+
+        assert_eq!(expected, root.to_serde_struct(&Options::quick_xml_de()));
+    }
+
     // https://github.com/Thomblin/xml_schema_generator/issues/3
     #[test]
     fn parse_multiple_children_as_vec() {


### PR DESCRIPTION
Hello! Thanks for making this; I've found myself having to wrangle some pre-existing XML in a side project without any previous experience with it, and trying to wrap my head around manually translating the schema into something serde could deal with was making my head spin.

The schema that I'm dealing with seems to have uncovered a bug in the generation of struct naming. Specifically, if an element has a descendant with the same name, the name of the struct generated is empty. For example:

shell commands:
```
$ echo '<foo><foo></foo</foo>' > foo.xml
$ xml_schema_generator foo.xml
```

shell commands:
```
use serde::{Deserialize, Serialize};

#[derive(Serialize, Deserialize)]
pub struct  {
    pub foo: FooFoo,
}

#[derive(Serialize, Deserialize)]
pub struct FooFoo {
}
```

This also happens when the repeat happens more than one level down:

input:
```
$ echo '<foo><bar><foo></foo</bar></foo>' > foobar.xml
$ xml_schema_generator foobar.xml
```

output:
```
use serde::{Deserialize, Serialize};

#[derive(Serialize, Deserialize)]
pub struct  {
    pub bar: Bar,
}

#[derive(Serialize, Deserialize)]
pub struct Bar {
    pub foo: FooBarFoo,
}

#[derive(Serialize, Deserialize)]
pub struct FooBarFoo {
}
```


From looking into the code, I found the `expand_name` function and noticed that I could enable logging to see if this was the cause, which it was; I appreciate your foresight to make the code nice and easy to debug!

I took a stab at fixing it and added a couple of tests to verify (which I also double-checked to make sure they failed when running with the existing version of `expand_name`), but if there's a better way of doing this, definitely feel free to push to the branch on my fork, copy the code and modify it into your own branch, or write something else entirely; I'm just happy to hopefully have helped a little after this project solved the problem I had :)